### PR TITLE
Add country support for sub-queries

### DIFF
--- a/itunespy/__init__.py
+++ b/itunespy/__init__.py
@@ -55,7 +55,7 @@ def search(term, country='US', media='all', entity=None, attribute=None, limit=5
     if result_count == 0:
         raise LookupError(search_error + str(term))
 
-    return _get_result_list(json)
+    return _get_result_list(json, country)
 
 # --------
 # Lookups
@@ -91,7 +91,7 @@ def lookup(id=None, artist_amg_id=None, upc=None, country='US', media='all', ent
     if result_count == 0:
         raise LookupError(lookup_error)
 
-    return _get_result_list(json)
+    return _get_result_list(json, country)
 
 # --------
 # Specific searches and lookups
@@ -211,7 +211,7 @@ lookup_no_ids = 'No id, amg id or upc arguments provided'
 # --------
 # Private
 # --------
-def _get_result_list(json):
+def _get_result_list(json, country=None):
     """
     Analyzes the provided JSON data and returns an array of result_item(s) based on its content
     :param json: Raw JSON data to analyze
@@ -266,6 +266,8 @@ def _get_result_list(json):
         else:
             unknown_result = result_item.ResultItem(item)
             result_list.append(unknown_result)
+
+        result_list[-1].country = country
 
     return result_list
 

--- a/itunespy/__init__.py
+++ b/itunespy/__init__.py
@@ -12,6 +12,7 @@
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
 
+import pycountry
 import requests
 from itunespy import music_artist
 from itunespy import music_album
@@ -211,7 +212,7 @@ lookup_no_ids = 'No id, amg id or upc arguments provided'
 # --------
 # Private
 # --------
-def _get_result_list(json, country=None):
+def _get_result_list(json, country):
     """
     Analyzes the provided JSON data and returns an array of result_item(s) based on its content
     :param json: Raw JSON data to analyze
@@ -220,6 +221,8 @@ def _get_result_list(json, country=None):
     result_list = []
 
     for item in json:
+        if 'country' not in item:
+            item['country'] = pycountry.countries.get(alpha_2=country).alpha_3
         if 'wrapperType' in item:
             # Music
             if item['wrapperType'] == 'artist' and item['artistType'] == 'Artist':
@@ -266,8 +269,6 @@ def _get_result_list(json, country=None):
         else:
             unknown_result = result_item.ResultItem(item)
             result_list.append(unknown_result)
-
-        result_list[-1].country = country
 
     return result_list
 

--- a/itunespy/ebook_artist.py
+++ b/itunespy/ebook_artist.py
@@ -31,4 +31,8 @@ class EbookArtist(result_item.ResultItem):
         Retrieves all the books published by the artist
         :return: List. Books published by the artist
         """
-        return itunespy.lookup(id=self.artist_id, entity=itunespy.entities['ebook'])[1:]
+        return itunespy.lookup(
+            id=self.artist_id,
+            entity=itunespy.entities['ebook'],
+            country=self.get_country()
+        )[1:]

--- a/itunespy/movie_artist.py
+++ b/itunespy/movie_artist.py
@@ -31,4 +31,8 @@ class MovieArtist(result_item.ResultItem):
         Retrieves all the movies published by the artist
         :return: List. Movies published by the artist
         """
-        return itunespy.lookup(id=self.artist_id, entity=itunespy.entities['movie'])[1:]
+        return itunespy.lookup(
+            id=self.artist_id,
+            entity=itunespy.entities['movie'],
+            country=self.get_country()
+        )[1:]

--- a/itunespy/music_album.py
+++ b/itunespy/music_album.py
@@ -19,12 +19,12 @@ class MusicAlbum(result_item.ResultItem):
     """
     Defines an Music Album
     """
-    def __init__(self, json):
+    def __init__(self, json, country=None):
         """
         Initializes the ResultItem class from the JSON provided
         :param json: String. Raw JSON data to fetch information from
         """
-        result_item.ResultItem.__init__(self, json)
+        result_item.ResultItem.__init__(self, json, country)
         self._track_list = []
         self._album_time = None
 
@@ -34,7 +34,7 @@ class MusicAlbum(result_item.ResultItem):
         :return: List. Tracks of the current album
         """
         if not self._track_list:
-            tracks = itunespy.lookup(id=self.collection_id, entity=itunespy.entities['song'])[1:]
+            tracks = itunespy.lookup(id=self.collection_id, country=self.country, entity=itunespy.entities['song'])[1:]
             for track in tracks:
                 self._track_list.append(track)
         return self._track_list

--- a/itunespy/music_album.py
+++ b/itunespy/music_album.py
@@ -19,12 +19,12 @@ class MusicAlbum(result_item.ResultItem):
     """
     Defines an Music Album
     """
-    def __init__(self, json, country=None):
+    def __init__(self, json):
         """
         Initializes the ResultItem class from the JSON provided
         :param json: String. Raw JSON data to fetch information from
         """
-        result_item.ResultItem.__init__(self, json, country)
+        result_item.ResultItem.__init__(self, json)
         self._track_list = []
         self._album_time = None
 
@@ -34,9 +34,12 @@ class MusicAlbum(result_item.ResultItem):
         :return: List. Tracks of the current album
         """
         if not self._track_list:
-            tracks = itunespy.lookup(id=self.collection_id, country=self.country, entity=itunespy.entities['song'])[1:]
-            for track in tracks:
-                self._track_list.append(track)
+            tracks = itunespy.lookup(
+                id=self.collection_id,
+                entity=itunespy.entities['song'],
+                country=self.get_country()
+            )[1:]
+            self._track_list.extend(tracks)
         return self._track_list
 
     def get_album_time(self, round_number=2):

--- a/itunespy/music_artist.py
+++ b/itunespy/music_artist.py
@@ -31,4 +31,8 @@ class MusicArtist(result_item.ResultItem):
         Retrieves all the albums by the artist
         :return: List. Albums published by the artist
         """
-        return itunespy.lookup(id=self.artist_id, entity=itunespy.entities['album'])[1:]
+        return itunespy.lookup(
+            id=self.artist_id,
+            entity=itunespy.entities['album'],
+            country=self.get_country()
+        )[1:]

--- a/itunespy/result_item.py
+++ b/itunespy/result_item.py
@@ -12,17 +12,18 @@
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
 
+import pycountry
+
 class ResultItem(object):
     """
     Defines a general result item
     """
-    def __init__(self, json, country=None):
+    def __init__(self, json):
         """
         Initializes the ResultItem class from the JSON provided
         :param json: String. Raw JSON data to fetch information from.
         The country is used for further requests from this item.
         """
-        self.country = country
         self.artist_name = json['artistName']
         self.type = None
 
@@ -238,6 +239,16 @@ class ResultItem(object):
 
         if 'minimumOsVersion' in json:
             self.minimum_os_version = json['minimumOsVersion']
+
+    def get_country(self, format='alpha_2'):
+        """
+        Returns the item's country in the specified format.
+
+        :param format: The format specifier. Must be supported by pycountry.
+                       Valid formats include 'alpha_2', 'alpha_3' and 'name'.
+        :return: String. The item's country in the specified format.
+        """
+        return getattr(pycountry.countries.get(alpha_3=self.country), format)
 
     def __repr__(self):
         """

--- a/itunespy/result_item.py
+++ b/itunespy/result_item.py
@@ -16,11 +16,13 @@ class ResultItem(object):
     """
     Defines a general result item
     """
-    def __init__(self, json):
+    def __init__(self, json, country=None):
         """
         Initializes the ResultItem class from the JSON provided
-        :param json: String. Raw JSON data to fetch information from
+        :param json: String. Raw JSON data to fetch information from.
+        The country is used for further requests from this item.
         """
+        self.country = country
         self.artist_name = json['artistName']
         self.type = None
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author_email='fgonzaleva@gmail.com',
     url='http://github.com/spaceisstrange/itunespy',
     packages=['itunespy'],
-    install_requires=['requests>=2.8'],
+    install_requires=['requests>=2.8', 'pycountry>=19.8'],
     license='MIT',
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
When searching the iTunes API it is possible to specify a `country`. This way one might get a `MusicAlgum` from the `_get_result_list` method. Using the `get_tracks` method on such an album will `lookup` the album. This however does not retain the country that was initially specified. For albums that are not available on the default (US) iTunes Store this causes `get_tracks` to effectively fail (no results are returned).

This pull request adds the `country` field to `ResultItem` and retains the `country` from a search or lookup operation in the respective results. It also modifies the `get_tracks` method to lookup tracks in the same `country` that the `MusicAlbum` belongs to.