### PR TITLE
Type hints and more

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI Pipeline
+on: push
+
+jobs:
+  lint:
+    name: Test Typing Conformance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.8"
+      - name: Install Dependencies
+        run: pip install .\[dev\]
+      - name: Run MyPy
+        uses: kolonialno/mypy-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          paths: itunespy

--- a/.gitignore
+++ b/.gitignore
@@ -53,12 +53,19 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
 # PyBuilder
 target/
 
 # PyCharm stuff
 *.iml
 .idea/
+venv/
 
 # Test file
 test.py
+

--- a/itunespy/__init__.py
+++ b/itunespy/__init__.py
@@ -55,7 +55,7 @@ def search(term, country='US', media='all', entity=None, attribute=None, limit=5
     if result_count == 0:
         raise LookupError(search_error + str(term))
 
-    return _get_result_list(json)
+    return _get_result_list(json, country)
 
 # --------
 # Lookups
@@ -91,7 +91,7 @@ def lookup(id=None, artist_amg_id=None, upc=None, country='US', media='all', ent
     if result_count == 0:
         raise LookupError(lookup_error)
 
-    return _get_result_list(json)
+    return _get_result_list(json, country)
 
 # --------
 # Specific searches and lookups
@@ -211,7 +211,7 @@ lookup_no_ids = 'No id, amg id or upc arguments provided'
 # --------
 # Private
 # --------
-def _get_result_list(json):
+def _get_result_list(json, country=None):
     """
     Analyzes the provided JSON data and returns an array of result_item(s) based on its content
     :param json: Raw JSON data to analyze
@@ -266,6 +266,8 @@ def _get_result_list(json):
         else:
             unknown_result = result_item.ResultItem(item)
             result_list.append(unknown_result)
+
+        result_list[-1].country = country
 
     return result_list
 

--- a/itunespy/__init__.py
+++ b/itunespy/__init__.py
@@ -15,7 +15,8 @@ from typing import Any, Dict, List, Union
 
 import pycountry
 import requests
-from urllib.parse import quote_plus, urlencode
+from urllib.parse import urlencode
+from itunespy import artist
 from itunespy import music_artist
 from itunespy import music_album
 from itunespy import movie_artist
@@ -123,41 +124,44 @@ def search_album(term: str, country: str = 'US', attribute: str = None, limit: i
 def search_track(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[track.Track]:
     return search(term, country, 'music', entities['song'], attribute, limit)  # type: ignore
 
-def lookup_artist(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[music_artist.MusicArtist]:
-    return lookup(id, artist_amg_id, upc, country, 'music', entities['musicArtist'], attribute, limit)  # type: ignore
+def lookup_artist(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
+    return lookup(id, artist_amg_id, upc, country, 'music', entities['musicArtist'], attribute, limit)
 
-def lookup_album(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[music_album.MusicAlbum]:
-    return lookup(id, artist_amg_id, upc, country, 'music', entities['album'], attribute, limit)  # type: ignore
+def lookup_album(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
+    return lookup(id, artist_amg_id, upc, country, 'music', entities['album'], attribute, limit)
 
-def lookup_track(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[track.Track]:
-    return lookup(id, artist_amg_id, upc, country, 'music', entities['song'], attribute, limit)  # type: ignore
+def lookup_track(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
+    return lookup(id, artist_amg_id, upc, country, 'music', entities['song'], attribute, limit)
 
 # Movies
-# FIXME: This returns MusicArtist for term "Michael"
-def search_director(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[movie_artist.MovieArtist]:
+def search_director(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[artist.Artist]:
+    # Unfortunately 'movieArtist' is not a valid entity so this method may return other artist types as well.
+    # Example: Search term 'Michael'
     return search(term, country, 'movie', entities['movieArtist'], attribute, limit)  # type: ignore
 
 def search_movie(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[track.Track]:
     return search(term, country, 'movie', entities['movie'], attribute, limit)  # type: ignore
 
-def lookup_directory(id: Union[str, int], country: str = 'US', attribute: str = None, limit: int = 50) -> List[movie_artist.MovieArtist]:
-    return lookup(id, None, None, country, 'movie', entities['movieArtist'], attribute, limit)  # type: ignore
+def lookup_directory(id: Union[str, int], country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
+    return lookup(id, None, None, country, 'movie', entities['movieArtist'], attribute, limit)
 
-def lookup_movie(id: Union[str, int], country: str = 'US', attribute: str = None, limit: int = 50) -> List[track.Track]:
-    return lookup(id, None, None, country, 'movie', entities['movie'], attribute, limit)  # type: ignore
+def lookup_movie(id: Union[str, int], country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
+    return lookup(id, None, None, country, 'movie', entities['movie'], attribute, limit)
 
 # Books
 def search_book(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
     return search(term, country, 'ebook', entities['ebook'], attribute, limit)
 
-def search_book_author(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[Union[ebook_artist.EbookArtist, music_artist.MusicArtist]]:
+def search_book_author(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[artist.Artist]:
+    # Unfortunately 'ebookAuthor' is not a valid entity so this method may return other artist types as well.
+    # Example: Search term 'test'
     return search(term, country, 'ebook', entities['ebookAuthor'], attribute, limit)  # type: ignore
 
 def lookup_book(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
     return lookup(id, artist_amg_id, upc, country, 'ebook', entities['ebook'], attribute, limit)
 
-def lookup_book_author(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[Union[ebook_artist.EbookArtist, music_artist.MusicArtist]]:
-    return lookup(id, artist_amg_id, upc, country, 'ebook', entities['ebookAuthor'], attribute, limit)  # type: ignore
+def lookup_book_author(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
+    return lookup(id, artist_amg_id, upc, country, 'ebook', entities['ebookAuthor'], attribute, limit)
 
 # TV Shows
 def search_tv_episodes(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:

--- a/itunespy/__init__.py
+++ b/itunespy/__init__.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Union
 
 import pycountry
 import requests
+from urllib.parse import quote_plus, urlencode
 from itunespy import music_artist
 from itunespy import music_album
 from itunespy import movie_artist
@@ -183,9 +184,8 @@ def search_mac_software(term: str, country: str = 'US', attribute: str = None, l
 # --------
 # Parameters
 # --------
-base_search_url = 'https://itunes.apple.com/search?term='
-base_lookup_url = 'https://itunes.apple.com/lookup?'
-ampersand = '&'
+base_search_url = 'https://itunes.apple.com/search'
+base_lookup_url = 'https://itunes.apple.com/lookup'
 entities = {
     'movieArtist': 'movieArtist',
     'movie': 'movie',
@@ -211,17 +211,6 @@ entities = {
     'all': 'all',
     'allArtist': 'allArtist',
     'allTrack': 'allTrack'
-}
-parameters = {
-    0: 'term=',
-    1: 'country=',
-    2: 'media=',
-    3: 'entity=',
-    4: 'attribute=',
-    5: 'limit=',
-    6: 'id=',
-    7: 'amgArtistId=',
-    8: 'upc='
 }
 general_no_connection = 'Cannot fetch JSON data'
 search_error = 'No results found with the keyword '
@@ -315,19 +304,18 @@ def _url_search_builder(
     :param limit: Integer. The number of search results you want the iTunes Store to return.
     :return: The built URL as a string
     """
-    built_url = base_search_url + _parse_query(term)
-    built_url += ampersand + parameters[1] + country
-    built_url += ampersand + parameters[2] + media
-
+    query = {
+        "term": term,
+        "country": country,
+        "media": media,
+        "limit": limit
+    }
     if entity is not None:
-        built_url += ampersand + parameters[3] + entity
-
+        query["entity"] = entity
     if attribute is not None:
-        built_url += ampersand + parameters[4] + attribute
+        query["attribute"] = attribute
 
-    built_url += ampersand + parameters[5] + str(limit)
-
-    return built_url
+    return base_search_url + "?" + urlencode(query)
 
 
 def _url_lookup_builder(id: Union[str, int] = None,
@@ -352,44 +340,23 @@ def _url_lookup_builder(id: Union[str, int] = None,
     :param limit: Integer. The number of search results you want the iTunes Store to return.
     :return: The built URL as a string
     """
-    built_url = base_lookup_url
+    query = {
+        "country": country,
+        "media": media,
+        "limit": limit
+    }
     has_one_argument = False
 
     if id is not None:
-        built_url += parameters[6] + str(id)
-        has_one_argument = True
-
+        query["id"] = id
     if artist_amg_id is not None:
-        if has_one_argument:
-            built_url += ampersand + parameters[7] + str(artist_amg_id)
-        else:
-            built_url += parameters[7] + str(artist_amg_id)
-            has_one_argument = True
-
+        query["amgArtistId"] = artist_amg_id
     if upc is not None:
-        if has_one_argument:
-            built_url += ampersand + parameters[8] + str(upc)
-        else:
-            built_url += parameters[8] + str(upc)
-
-    built_url += ampersand + parameters[1] + country
-    built_url += ampersand + parameters[2] + media
+        query["upc"] = upc
 
     if entity is not None:
-        built_url += ampersand + parameters[3] + entity
-
+        query["entity"] = entity
     if attribute is not None:
-        built_url += ampersand + parameters[4] + attribute
+        query["attribute"] = attribute
 
-    built_url += ampersand + parameters[5] + str(limit)
-
-    return built_url
-
-
-def _parse_query(query: str) -> str:
-    """
-    Replaces every space in the provided query with a +
-    :param query: term to delete spaces
-    :return: query without spaces as a string
-    """
-    return str(query).replace(' ', '+')
+    return base_lookup_url + "?" + urlencode(query)

--- a/itunespy/__init__.py
+++ b/itunespy/__init__.py
@@ -11,6 +11,7 @@
 # You should have received a
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
+from typing import Any, Dict, List, Union
 
 import pycountry
 import requests
@@ -30,7 +31,13 @@ from itunespy import result_item
 # --------
 # Searches
 # --------
-def search(term, country='US', media='all', entity=None, attribute=None, limit=50):
+def search(
+        term: str,
+        country: str = 'US',
+        media: str = 'all',
+        entity: str = None,
+        attribute: str = None,
+        limit: int = 50) -> List[result_item.ResultItem]:
     """
     Returns the result of the search of the specified term in an array of result_item(s)
     :param term: String. The URL-encoded text string you want to search for. Example: Steven Wilson.
@@ -61,7 +68,15 @@ def search(term, country='US', media='all', entity=None, attribute=None, limit=5
 # --------
 # Lookups
 # --------
-def lookup(id=None, artist_amg_id=None, upc=None, country='US', media='all', entity=None, attribute=None, limit=50):
+def lookup(
+        id: Union[str, int] = None,
+        artist_amg_id: Union[str, int] = None,
+        upc: Union[str, int] = None,
+        country: str = 'US',
+        media: str = 'all',
+        entity: str = None,
+        attribute: str = None,
+        limit: int = 50) -> List[result_item.ResultItem]:
     """
     Returns the result of the lookup of the specified id, artist_amg_id or upc in an array of result_item(s)
     :param id: String. iTunes ID of the artist, album, track, ebook or software
@@ -98,65 +113,72 @@ def lookup(id=None, artist_amg_id=None, upc=None, country='US', media='all', ent
 # Specific searches and lookups
 # --------
 # Music
-def search_artist(term, country='US', attribute=None, limit=50):
-    return search(term, country, 'music', entities['musicArtist'], attribute, limit)
+def search_artist(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[music_artist.MusicArtist]:
+    return search(term, country, 'music', entities['musicArtist'], attribute, limit)  # type: ignore
 
-def search_album(term, country='US', attribute=None, limit=50):
-    return search(term, country, 'music', entities['album'], attribute, limit)
+def search_album(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[music_album.MusicAlbum]:
+    return search(term, country, 'music', entities['album'], attribute, limit)  # type: ignore
 
-def search_track(term, country='US', attribute=None, limit=50):
-    return search(term, country, 'music', entities['song'], attribute, limit)
+def search_track(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[track.Track]:
+    return search(term, country, 'music', entities['song'], attribute, limit)  # type: ignore
 
-def lookup_artist(id=None, artist_amg_id=None, upc=None, country='US', attribute=None, limit=50):
-    return lookup(id, artist_amg_id, upc, country, 'music', entities['musicArtist'], attribute, limit)
+def lookup_artist(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[music_artist.MusicArtist]:
+    return lookup(id, artist_amg_id, upc, country, 'music', entities['musicArtist'], attribute, limit)  # type: ignore
 
-def lookup_album(id=None, artist_amg_id=None, upc=None, country='US', attribute=None, limit=50):
-    return lookup(id, artist_amg_id, upc, country, 'music', entities['album'], attribute, limit)
+def lookup_album(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[music_album.MusicAlbum]:
+    return lookup(id, artist_amg_id, upc, country, 'music', entities['album'], attribute, limit)  # type: ignore
 
-def lookup_track(id=None, artist_amg_id=None, upc=None, country='US', attribute=None, limit=50):
-    return lookup(id, artist_amg_id, upc, country, 'music', entities['song'], attribute, limit)
+def lookup_track(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[track.Track]:
+    return lookup(id, artist_amg_id, upc, country, 'music', entities['song'], attribute, limit)  # type: ignore
 
 # Movies
-def search_director(term, country='US', attribute=None, limit=50):
-    return search(term, country, 'movie', entities['movieArtist'], attribute, limit)
+# FIXME: This returns MusicArtist for term "Michael"
+def search_director(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[movie_artist.MovieArtist]:
+    return search(term, country, 'movie', entities['movieArtist'], attribute, limit)  # type: ignore
 
-def search_movie(term, country='US', attribute=None, limit=50):
-    return search(term, country, 'movie', entities['movie'], attribute, limit)
+def search_movie(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[track.Track]:
+    return search(term, country, 'movie', entities['movie'], attribute, limit)  # type: ignore
+
+def lookup_directory(id: Union[str, int], country: str = 'US', attribute: str = None, limit: int = 50) -> List[movie_artist.MovieArtist]:
+    return lookup(id, None, None, country, 'movie', entities['movieArtist'], attribute, limit)  # type: ignore
+
+def lookup_movie(id: Union[str, int], country: str = 'US', attribute: str = None, limit: int = 50) -> List[track.Track]:
+    return lookup(id, None, None, country, 'movie', entities['movie'], attribute, limit)  # type: ignore
 
 # Books
-def search_book(term, country='US', attribute=None, limit=50):
+def search_book(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
     return search(term, country, 'ebook', entities['ebook'], attribute, limit)
 
-def search_book_author(term, country='US', attribute=None, limit=50):
-    return search(term, country, 'ebook', entities['ebookAuthor'], attribute, limit)
+def search_book_author(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[Union[ebook_artist.EbookArtist, music_artist.MusicArtist]]:
+    return search(term, country, 'ebook', entities['ebookAuthor'], attribute, limit)  # type: ignore
 
-def lookup_book(id=None, artist_amg_id=None, upc=None, country='US', attribute=None, limit=50):
+def lookup_book(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
     return lookup(id, artist_amg_id, upc, country, 'ebook', entities['ebook'], attribute, limit)
 
-def lookup_book_author(id=None, artist_amg_id=None, upc=None, country='US', attribute=None, limit=50):
-    return lookup(id, artist_amg_id, upc, country, 'ebook', entities['ebookAuthor'], attribute, limit)
+def lookup_book_author(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[Union[ebook_artist.EbookArtist, music_artist.MusicArtist]]:
+    return lookup(id, artist_amg_id, upc, country, 'ebook', entities['ebookAuthor'], attribute, limit)  # type: ignore
 
 # TV Shows
-def search_tv_episodes(term, country='US', attribute=None, limit=50):
+def search_tv_episodes(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
     return search(term, country, 'tvShow', entities['tvEpisode'], attribute, limit)
 
-def search_tv_season(term, country='US', attribute=None, limit=50):
+def search_tv_season(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
     return search(term, country, 'tvShow', entities['tvSeason'], attribute, limit)
 
-def lookup_tv_episodes(id=None, artist_amg_id=None, upc=None, country='US', attribute=None, limit=50):
+def lookup_tv_episodes(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
     return lookup(id, artist_amg_id, upc, country, 'tvShow', entities['tvEpisode'], attribute, limit)
 
-def lookup_tv_season(id=None, artist_amg_id=None, upc=None, country='US', attribute=None, limit=50):
+def lookup_tv_season(id: Union[str, int] = None, artist_amg_id: Union[str, int] = None, upc: Union[str, int] = None, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
     return lookup(id, artist_amg_id, upc, country, 'tvShow', entities['tvSeason'], attribute, limit)
 
 # Software
-def search_software(term, country='US', attribute=None, limit=50):
+def search_software(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
     return search(term, country, 'software', entities['software'], attribute, limit)
 
-def search_ipad_software(term, country='US', attribute=None, limit=50):
+def search_ipad_software(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
     return search(term, country, 'software', entities['iPadSoftware'], attribute, limit)
 
-def search_mac_software(term, country='US', attribute=None, limit=50):
+def search_mac_software(term: str, country: str = 'US', attribute: str = None, limit: int = 50) -> List[result_item.ResultItem]:
     return search(term, country, 'software', entities['macSoftware'], attribute, limit)
 # --------
 # Parameters
@@ -212,13 +234,13 @@ lookup_no_ids = 'No id, amg id or upc arguments provided'
 # --------
 # Private
 # --------
-def _get_result_list(json, country):
+def _get_result_list(json: List[Dict[str, Any]], country: str) -> List[result_item.ResultItem]:
     """
     Analyzes the provided JSON data and returns an array of result_item(s) based on its content
     :param json: Raw JSON data to analyze
     :return: An array of result_item(s) from the provided JSON data
     """
-    result_list = []
+    result_list: List[result_item.ResultItem] = []
 
     for item in json:
         if 'country' not in item:
@@ -273,7 +295,13 @@ def _get_result_list(json, country):
     return result_list
 
 
-def _url_search_builder(term, country='US', media='all', entity=None, attribute=None, limit=50):
+def _url_search_builder(
+        term: str,
+        country: str = 'US',
+        media: str = 'all',
+        entity: str = None,
+        attribute: str = None,
+        limit: int = 50) -> str:
     """
     Builds the URL to perform the search based on the provided data
     :param term: String. The URL-encoded text string you want to search for. Example: Steven Wilson.
@@ -302,8 +330,14 @@ def _url_search_builder(term, country='US', media='all', entity=None, attribute=
     return built_url
 
 
-def _url_lookup_builder(id=None, artist_amg_id=None, upc=None, country='US', media='music', entity=None, attribute=None,
-                        limit=50):
+def _url_lookup_builder(id: Union[str, int] = None,
+                        artist_amg_id: Union[str, int] = None,
+                        upc: Union[str, int] = None,
+                        country: str = 'US',
+                        media: str = 'music',
+                        entity: str = None,
+                        attribute: str = None,
+                        limit: int = 50) -> str:
     """
     Builds the URL to perform the lookup based on the provided data
     :param id: String. iTunes ID of the artist, album, track, ebook or software
@@ -327,14 +361,14 @@ def _url_lookup_builder(id=None, artist_amg_id=None, upc=None, country='US', med
 
     if artist_amg_id is not None:
         if has_one_argument:
-            built_url += ampersand + parameters[7] + artist_amg_id
+            built_url += ampersand + parameters[7] + str(artist_amg_id)
         else:
             built_url += parameters[7] + str(artist_amg_id)
             has_one_argument = True
 
     if upc is not None:
         if has_one_argument:
-            built_url += ampersand + parameters[8] + upc
+            built_url += ampersand + parameters[8] + str(upc)
         else:
             built_url += parameters[8] + str(upc)
 
@@ -352,7 +386,7 @@ def _url_lookup_builder(id=None, artist_amg_id=None, upc=None, country='US', med
     return built_url
 
 
-def _parse_query(query):
+def _parse_query(query: str) -> str:
     """
     Replaces every space in the provided query with a +
     :param query: term to delete spaces

--- a/itunespy/__init__.py
+++ b/itunespy/__init__.py
@@ -12,6 +12,7 @@
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
 
+import pycountry
 import requests
 from itunespy import music_artist
 from itunespy import music_album
@@ -211,7 +212,7 @@ lookup_no_ids = 'No id, amg id or upc arguments provided'
 # --------
 # Private
 # --------
-def _get_result_list(json, country=None):
+def _get_result_list(json, country):
     """
     Analyzes the provided JSON data and returns an array of result_item(s) based on its content
     :param json: Raw JSON data to analyze
@@ -220,6 +221,8 @@ def _get_result_list(json, country=None):
     result_list = []
 
     for item in json:
+        if 'country' not in item:
+            item['country'] = pycountry.countries.get(alpha_2=country).alpha_3
         if 'wrapperType' in item:
             # Music
             if item['wrapperType'] == 'artist' and item['artistType'] == 'Artist':
@@ -266,8 +269,6 @@ def _get_result_list(json, country=None):
         else:
             unknown_result = result_item.ResultItem(item)
             result_list.append(unknown_result)
-
-        result_list[-1].country = country
 
     return result_list
 

--- a/itunespy/__init__.py
+++ b/itunespy/__init__.py
@@ -11,6 +11,13 @@
 # You should have received a
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
+
+'''
+    This is a simple module made in my free time. It's not perfect, but it works well.
+    I'm accepting any pull request to improve it, just follow the code style.
+    For examples and documentation, take a look at the README.md
+'''
+
 from typing import Any, Dict, List, Union
 
 import pycountry
@@ -24,11 +31,6 @@ from itunespy import ebook_artist
 from itunespy import track
 from itunespy import result_item
 
-'''
-    This is a simple module made in my free time. It's not perfect, but it works well.
-    I'm accepting any pull request to improve it, just follow the code style.
-    For examples and documentation, take a look at the README.md
-'''
 
 # --------
 # Searches
@@ -103,7 +105,7 @@ def lookup(
     try:
         json = r.json()['results']
         result_count = r.json()['resultCount']
-    except:
+    except KeyError:
         raise ConnectionError(general_no_connection)
 
     if result_count == 0:

--- a/itunespy/artist.py
+++ b/itunespy/artist.py
@@ -11,21 +11,9 @@
 # You should have received a
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
-from typing import Any, Dict, List
+from itunespy import result_item
 
-import itunespy
-from itunespy import artist, result_item
-
-class EbookArtist(artist.Artist):
+class Artist(result_item.ResultItem):
     """
-    Defines an eBook Artist
+    Defines an Artist
     """
-    def get_books(self) -> List[result_item.ResultItem]:
-        """
-        Retrieves all the books published by the artist
-        :return: List. Books published by the artist
-        """
-        return itunespy.lookup_book(
-            id=self.artist_id,
-            country=self.get_country()
-        )[1:]

--- a/itunespy/artist.py
+++ b/itunespy/artist.py
@@ -13,6 +13,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>
 from itunespy import result_item
 
+
 class Artist(result_item.ResultItem):
     """
     Defines an Artist

--- a/itunespy/ebook_artist.py
+++ b/itunespy/ebook_artist.py
@@ -11,6 +11,7 @@
 # You should have received a
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
+from typing import Any, Dict, List
 
 import itunespy
 from itunespy import result_item
@@ -19,20 +20,19 @@ class EbookArtist(result_item.ResultItem):
     """
     Defines an eBook Artist
     """
-    def __init__(self, json):
+    def __init__(self, json: Dict[str, Any]) -> None:
         """
         Initializes the ResultItem class from the JSON provided
         :param json: String. Raw JSON data to fetch information from
         """
         result_item.ResultItem.__init__(self, json)
 
-    def get_books(self):
+    def get_books(self) -> List[result_item.ResultItem]:
         """
         Retrieves all the books published by the artist
         :return: List. Books published by the artist
         """
-        return itunespy.lookup(
+        return itunespy.lookup_book(
             id=self.artist_id,
-            entity=itunespy.entities['ebook'],
             country=self.get_country()
         )[1:]

--- a/itunespy/ebook_artist.py
+++ b/itunespy/ebook_artist.py
@@ -11,10 +11,11 @@
 # You should have received a
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
-from typing import Any, Dict, List
+from typing import List
 
 import itunespy
 from itunespy import artist, result_item
+
 
 class EbookArtist(artist.Artist):
     """

--- a/itunespy/ebook_artist.py
+++ b/itunespy/ebook_artist.py
@@ -31,4 +31,8 @@ class EbookArtist(result_item.ResultItem):
         Retrieves all the books published by the artist
         :return: List. Books published by the artist
         """
-        return itunespy.lookup(id=self.artist_id, entity=itunespy.entities['ebook'])[1:]
+        return itunespy.lookup(
+            id=self.artist_id,
+            entity=itunespy.entities['ebook'],
+            country=self.get_country()
+        )[1:]

--- a/itunespy/movie_artist.py
+++ b/itunespy/movie_artist.py
@@ -11,10 +11,10 @@
 # You should have received a
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
-from typing import Any, Dict, List
+from typing import List
 
 import itunespy
-from itunespy import artist, result_item, track
+from itunespy import artist, track
 
 
 class MovieArtist(artist.Artist):

--- a/itunespy/movie_artist.py
+++ b/itunespy/movie_artist.py
@@ -31,4 +31,8 @@ class MovieArtist(result_item.ResultItem):
         Retrieves all the movies published by the artist
         :return: List. Movies published by the artist
         """
-        return itunespy.lookup(id=self.artist_id, entity=itunespy.entities['movie'])[1:]
+        return itunespy.lookup(
+            id=self.artist_id,
+            entity=itunespy.entities['movie'],
+            country=self.get_country()
+        )[1:]

--- a/itunespy/movie_artist.py
+++ b/itunespy/movie_artist.py
@@ -11,28 +11,29 @@
 # You should have received a
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
+from typing import Any, Dict, List
 
 import itunespy
-from itunespy import result_item
+from itunespy import result_item, track
+
 
 class MovieArtist(result_item.ResultItem):
     """
     Defines an Movie Artist
     """
-    def __init__(self, json):
+    def __init__(self, json: Dict[str, Any]) -> None:
         """
         Initializes the ResultItem class from the JSON provided
         :param json: String. Raw JSON data to fetch information from
         """
         result_item.ResultItem.__init__(self, json)
 
-    def get_movies(self):
+    def get_movies(self) -> List[track.Track]:
         """
         Retrieves all the movies published by the artist
         :return: List. Movies published by the artist
         """
-        return itunespy.lookup(
+        return itunespy.lookup_movie(
             id=self.artist_id,
-            entity=itunespy.entities['movie'],
             country=self.get_country()
         )[1:]

--- a/itunespy/movie_artist.py
+++ b/itunespy/movie_artist.py
@@ -14,26 +14,19 @@
 from typing import Any, Dict, List
 
 import itunespy
-from itunespy import result_item, track
+from itunespy import artist, result_item, track
 
 
-class MovieArtist(result_item.ResultItem):
+class MovieArtist(artist.Artist):
     """
     Defines an Movie Artist
     """
-    def __init__(self, json: Dict[str, Any]) -> None:
-        """
-        Initializes the ResultItem class from the JSON provided
-        :param json: String. Raw JSON data to fetch information from
-        """
-        result_item.ResultItem.__init__(self, json)
-
     def get_movies(self) -> List[track.Track]:
         """
         Retrieves all the movies published by the artist
         :return: List. Movies published by the artist
         """
-        return itunespy.lookup_movie(
-            id=self.artist_id,
-            country=self.get_country()
-        )[1:]
+        return [item for item in
+                itunespy.lookup_movie(id=self.artist_id,
+                                      country=self.get_country())
+                if isinstance(item, track.Track)]

--- a/itunespy/music_album.py
+++ b/itunespy/music_album.py
@@ -26,7 +26,7 @@ class MusicAlbum(result_item.ResultItem):
         Initializes the ResultItem class from the JSON provided
         :param json: String. Raw JSON data to fetch information from
         """
-        result_item.ResultItem.__init__(self, json)
+        super().__init__(json)
         self._track_list: List[track.Track] = []
         self._album_time: Optional[float] = None
 
@@ -36,10 +36,10 @@ class MusicAlbum(result_item.ResultItem):
         :return: List. Tracks of the current album
         """
         if not self._track_list:
-            tracks = itunespy.lookup_track(
-                id=self.collection_id,
-                country=self.get_country()
-            )[1:]
+            tracks = [item for item in
+                      itunespy.lookup_track(id=self.collection_id,
+                                            country=self.get_country())
+                      if isinstance(item, track.Track)]
             self._track_list.extend(tracks)
         return self._track_list
 

--- a/itunespy/music_album.py
+++ b/itunespy/music_album.py
@@ -11,42 +11,43 @@
 # You should have received a
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
+from typing import Any, Dict, List, Optional
 
 import itunespy
-from itunespy import result_item
+from itunespy import result_item, track
+
 
 class MusicAlbum(result_item.ResultItem):
     """
     Defines an Music Album
     """
-    def __init__(self, json):
+    def __init__(self, json: Dict[str, Any]) -> None:
         """
         Initializes the ResultItem class from the JSON provided
         :param json: String. Raw JSON data to fetch information from
         """
         result_item.ResultItem.__init__(self, json)
-        self._track_list = []
-        self._album_time = None
+        self._track_list: List[track.Track] = []
+        self._album_time: Optional[float] = None
 
-    def get_tracks(self):
+    def get_tracks(self) -> List[track.Track]:
         """
         Retrieves all the tracks of the album if they haven't been retrieved yet
         :return: List. Tracks of the current album
         """
         if not self._track_list:
-            tracks = itunespy.lookup(
+            tracks = itunespy.lookup_track(
                 id=self.collection_id,
-                entity=itunespy.entities['song'],
                 country=self.get_country()
             )[1:]
             self._track_list.extend(tracks)
         return self._track_list
 
-    def get_album_time(self, round_number=2):
+    def get_album_time(self, round_number: int = 2) -> float:
         """
         Retrieves all of the track's length and returns the sum of all
         :param round_number: Int. Number of decimals to round the sum
-        :return: Int. Sum of all the track's length
+        :return: Float. Sum of all the track's length
         """
         if not self._track_list:
             self.get_tracks()

--- a/itunespy/music_album.py
+++ b/itunespy/music_album.py
@@ -19,12 +19,12 @@ class MusicAlbum(result_item.ResultItem):
     """
     Defines an Music Album
     """
-    def __init__(self, json):
+    def __init__(self, json, country=None):
         """
         Initializes the ResultItem class from the JSON provided
         :param json: String. Raw JSON data to fetch information from
         """
-        result_item.ResultItem.__init__(self, json)
+        result_item.ResultItem.__init__(self, json, country)
         self._track_list = []
         self._album_time = None
 
@@ -34,7 +34,7 @@ class MusicAlbum(result_item.ResultItem):
         :return: List. Tracks of the current album
         """
         if not self._track_list:
-            tracks = itunespy.lookup(id=self.collection_id, entity=itunespy.entities['song'])[1:]
+            tracks = itunespy.lookup(id=self.collection_id, country=self.country, entity=itunespy.entities['song'])[1:]
             for track in tracks:
                 self._track_list.append(track)
         return self._track_list

--- a/itunespy/music_album.py
+++ b/itunespy/music_album.py
@@ -19,12 +19,12 @@ class MusicAlbum(result_item.ResultItem):
     """
     Defines an Music Album
     """
-    def __init__(self, json, country=None):
+    def __init__(self, json):
         """
         Initializes the ResultItem class from the JSON provided
         :param json: String. Raw JSON data to fetch information from
         """
-        result_item.ResultItem.__init__(self, json, country)
+        result_item.ResultItem.__init__(self, json)
         self._track_list = []
         self._album_time = None
 
@@ -34,9 +34,12 @@ class MusicAlbum(result_item.ResultItem):
         :return: List. Tracks of the current album
         """
         if not self._track_list:
-            tracks = itunespy.lookup(id=self.collection_id, country=self.country, entity=itunespy.entities['song'])[1:]
-            for track in tracks:
-                self._track_list.append(track)
+            tracks = itunespy.lookup(
+                id=self.collection_id,
+                entity=itunespy.entities['song'],
+                country=self.get_country()
+            )[1:]
+            self._track_list.extend(tracks)
         return self._track_list
 
     def get_album_time(self, round_number=2):

--- a/itunespy/music_artist.py
+++ b/itunespy/music_artist.py
@@ -11,28 +11,28 @@
 # You should have received a
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
+from typing import Any, Dict, List
 
 import itunespy
-from itunespy import result_item
+from itunespy import music_album, result_item
 
 class MusicArtist(result_item.ResultItem):
     """
     Defines an Music Artist
     """
-    def __init__(self, json):
+    def __init__(self, json: Dict[str, Any]) -> None:
         """
         Initializes the ResultItem class from the JSON provided
         :param json: String. Raw JSON data to fetch information from
         """
         result_item.ResultItem.__init__(self, json)
 
-    def get_albums(self):
+    def get_albums(self) -> List[music_album.MusicAlbum]:
         """
         Retrieves all the albums by the artist
         :return: List. Albums published by the artist
         """
-        return itunespy.lookup(
+        return itunespy.lookup_album(
             id=self.artist_id,
-            entity=itunespy.entities['album'],
             country=self.get_country()
         )[1:]

--- a/itunespy/music_artist.py
+++ b/itunespy/music_artist.py
@@ -11,10 +11,11 @@
 # You should have received a
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
-from typing import Any, Dict, List
+from typing import List
 
 import itunespy
-from itunespy import artist, music_album, result_item
+from itunespy import artist, music_album
+
 
 class MusicArtist(artist.Artist):
     """

--- a/itunespy/music_artist.py
+++ b/itunespy/music_artist.py
@@ -14,25 +14,18 @@
 from typing import Any, Dict, List
 
 import itunespy
-from itunespy import music_album, result_item
+from itunespy import artist, music_album, result_item
 
-class MusicArtist(result_item.ResultItem):
+class MusicArtist(artist.Artist):
     """
     Defines an Music Artist
     """
-    def __init__(self, json: Dict[str, Any]) -> None:
-        """
-        Initializes the ResultItem class from the JSON provided
-        :param json: String. Raw JSON data to fetch information from
-        """
-        result_item.ResultItem.__init__(self, json)
-
     def get_albums(self) -> List[music_album.MusicAlbum]:
         """
         Retrieves all the albums by the artist
         :return: List. Albums published by the artist
         """
-        return itunespy.lookup_album(
-            id=self.artist_id,
-            country=self.get_country()
-        )[1:]
+        return [item for item in
+                itunespy.lookup_album(id=self.artist_id,
+                                      country=self.get_country())
+                if isinstance(item, music_album.MusicAlbum)]

--- a/itunespy/music_artist.py
+++ b/itunespy/music_artist.py
@@ -31,4 +31,8 @@ class MusicArtist(result_item.ResultItem):
         Retrieves all the albums by the artist
         :return: List. Albums published by the artist
         """
-        return itunespy.lookup(id=self.artist_id, entity=itunespy.entities['album'])[1:]
+        return itunespy.lookup(
+            id=self.artist_id,
+            entity=itunespy.entities['album'],
+            country=self.get_country()
+        )[1:]

--- a/itunespy/result_item.py
+++ b/itunespy/result_item.py
@@ -12,17 +12,18 @@
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
 
+import pycountry
+
 class ResultItem(object):
     """
     Defines a general result item
     """
-    def __init__(self, json, country=None):
+    def __init__(self, json):
         """
         Initializes the ResultItem class from the JSON provided
         :param json: String. Raw JSON data to fetch information from.
         The country is used for further requests from this item.
         """
-        self.country = country
         self.artist_name = json['artistName']
         self.type = None
 
@@ -238,6 +239,16 @@ class ResultItem(object):
 
         if 'minimumOsVersion' in json:
             self.minimum_os_version = json['minimumOsVersion']
+
+    def get_country(self, format='alpha_2'):
+        """
+        Returns the item's country in the specified format.
+
+        :param format: The format specifier. Must be supported by pycountry.
+                       Valid formats include 'alpha_2', 'alpha_3' and 'name'.
+        :return: String. The item's country in the specified format.
+        """
+        return getattr(pycountry.countries.get(alpha_3=self.country), format)
 
     def __repr__(self):
         """

--- a/itunespy/result_item.py
+++ b/itunespy/result_item.py
@@ -11,7 +11,8 @@
 # You should have received a
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+import json
+from typing import Any, Dict, List, TYPE_CHECKING
 
 import copy
 import pycountry
@@ -153,10 +154,4 @@ class ResultItem(object):
         Retrieves all keys in the class as a String
         :return: String. All the keys available in the class
         """
-        string = ''
-
-        for key, value in self.__dict__.items():
-            if not key.startswith('__'):
-                string += '\n' + key + ':' + str(value)
-
-        return string
+        return json.dumps(self.json, indent=2)

--- a/itunespy/result_item.py
+++ b/itunespy/result_item.py
@@ -16,11 +16,13 @@ class ResultItem(object):
     """
     Defines a general result item
     """
-    def __init__(self, json):
+    def __init__(self, json, country=None):
         """
         Initializes the ResultItem class from the JSON provided
-        :param json: String. Raw JSON data to fetch information from
+        :param json: String. Raw JSON data to fetch information from.
+        The country is used for further requests from this item.
         """
+        self.country = country
         self.artist_name = json['artistName']
         self.type = None
 

--- a/itunespy/result_item.py
+++ b/itunespy/result_item.py
@@ -103,30 +103,32 @@ class ResultItem(object):
         """
         self.json = copy.deepcopy(json)
 
-        self.type: Optional[str] = None
-        if 'wrapperType' in json:
-            self.type = json['wrapperType']
+    @property
+    def type(self) -> str:
+        return self.json.get('wrapperType') or self.kind  # type: ignore
 
-            if 'collectionType' in json:
-                self.collection_type: str = json['collectionType']
-            elif 'artistType' in json:
-                self.artist_type: str = json['artistType']
-            elif 'kind' in json:
-                self.track_type: str = json['kind']
-        elif 'kind' in json:
-            self.type = json['kind']
+    @property
+    def track_type(self) -> str:
+        if 'wrapperType' in self.json:
+            return self.kind  # type: ignore
+        else:
+            raise AttributeError
 
-        if 'radioStationUrl' in json:
-            self.artist_radio_url: str = json['radioStationUrl']
+    @property
+    def artist_radio_url(self) -> str:
+        return self.json["radioStationUrl"]  # type: ignore
 
-        if 'trackTimeMillis' in json:
-            self.track_time: int = json['trackTimeMillis']
+    @property
+    def track_time(self) -> int:
+        return self.json["trackTimeMillis"]  # type: ignore
 
-        if 'fileSizeBytes' in json:
-            self.file_size = json['fileSizeBytes']
+    @property
+    def file_size(self) -> int:
+        return self.json["fileSizeBytes"]  # type: ignore
 
-        if 'languageCodesISO2A' in json:
-            self.language_codes = json['languageCodesISO2A']
+    @property
+    def language_codes(self) -> List[str]:
+        return self.json["languageCodesISO2A"]  # type: ignore
 
     def __getattr__(self, item: str) -> Any:
         components = item.split('_')

--- a/itunespy/result_item.py
+++ b/itunespy/result_item.py
@@ -11,236 +11,132 @@
 # You should have received a
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
+import copy
 import pycountry
+
 
 class ResultItem(object):
     """
     Defines a general result item
     """
-    def __init__(self, json):
+
+    if TYPE_CHECKING:
+        # These fields are dynamically queried. They are defined here to help
+        # type checkers and IDEs.
+        primary_genre_id: int
+        primary_genre_name: str
+
+        artist_id: int
+        amg_artist_id: int
+        artist_name: str
+        artist_link_url: str
+        artist_view_url: str
+
+        track_id: int
+        track_name: str
+        track_censored_name: str
+        track_view_url: str
+        track_number: int
+        track_count: int
+        preview_url: str
+        artwork_url_30: str
+        artwork_url_60: str
+        artwork_url_100: str
+        artwork_url_512: str
+        track_price: float
+        track_hd_price: float
+        track_rental_price: float
+        track_hd_rental_price: float
+        release_date: str
+        track_explicitness: str
+        disc_count: int
+        disc_number: int
+        country: str
+        currency: str
+        content_advisory_rating: str
+        short_description: str
+        long_description: str
+        is_streamable: bool
+
+        collection_id: int
+        collection_name: str
+        collection_censored_name: str
+        collection_view_url: str
+        collection_price: float
+        collection_hd_price: float
+        collection_explicitness: str
+        copyright: str
+
+        genres: List[str]
+        genre_ids: List[str]
+        price: float
+        description: str
+        formatted_price: str
+
+        artist_ids: List[str]
+        average_user_rating: float
+        user_rating_count: int
+        average_user_rating_for_current_version: float
+        user_rating_count_for_current_version: int
+        screenshort_urls: List[str]
+        ipad_screenshot_urls: List[str]
+        features: List[str]
+        supported_devices: List[str]
+        advisories: List[str]
+        is_game_center_enabled: bool
+        track_content_rating: str
+        version: str
+        seller_name: str
+        seller_url: str
+        bundle_id: str
+        release_notes: str
+        is_vpp_device_based_licensing_enabled: bool
+        minimum_os_version: str
+
+    def __init__(self, json: Dict[str, Any]) -> None:
         """
         Initializes the ResultItem class from the JSON provided
         :param json: String. Raw JSON data to fetch information from.
         The country is used for further requests from this item.
         """
-        self.artist_name = json['artistName']
-        self.type = None
+        self.json = copy.deepcopy(json)
 
+        self.type: Optional[str] = None
         if 'wrapperType' in json:
             self.type = json['wrapperType']
 
             if 'collectionType' in json:
-                self.collection_type = json['collectionType']
+                self.collection_type: str = json['collectionType']
             elif 'artistType' in json:
-                self.artist_type = json['artistType']
+                self.artist_type: str = json['artistType']
             elif 'kind' in json:
-                self.track_type = json['kind']
+                self.track_type: str = json['kind']
         elif 'kind' in json:
             self.type = json['kind']
 
-        if 'primaryGenreName' in json:
-            self.primary_genre_name = json['primaryGenreName']
-
-        if 'artistId' in json:
-            self.artist_id = json['artistId']
-
-        if 'artistLinkUrl' in json:
-            self.artist_link_url = json['artistLinkUrl']
-
         if 'radioStationUrl' in json:
-            self.artist_radio_url = json['radioStationUrl']
-
-        if 'primaryGenreId' in json:
-            self.primary_genre_id = json['primaryGenreId']
-
-        if 'amgArtistId' in json:
-            self.artist_amg_id = json['amgArtistId']
-
-        if 'artistViewUrl' in json:
-            self.artist_view_url = json['artistViewUrl']
-
-        if 'trackName' in json:
-            self.track_name = json['trackName']
-
-        if 'trackId' in json:
-            self.track_id = json['trackId']
-
-        if 'trackCensoredName' in json:
-            self.track_censored_name = json['trackCensoredName']
-
-        if 'trackViewUrl' in json:
-            self.track_view_url = json['trackViewUrl']
-
-        if 'trackCount' in json:
-            self.track_count = json['trackCount']
-
-        if 'trackNumber' in json:
-            self.track_number = json['trackNumber']
-
-        if 'previewUrl' in json:
-            self.preview_url = json['previewUrl']
-
-        if 'artworkUrl30' in json:
-            self.artwork_url_30 = json['artworkUrl30']
-
-        if 'artworkUrl60' in json:
-            self.artwork_url_60 = json['artworkUrl60']
-
-        if 'artworkUrl100' in json:
-            self.artwork_url_100 = json['artworkUrl100']
-
-        if 'artworkUrl512' in json:
-            self.artwork_url_512 = json['artworkUrl512']
-
-        if 'collectionName' in json:
-            self.collection_name = json['collectionName']
-
-        if 'collectionId' in json:
-            self.collection_id = json['collectionId']
-
-        if 'collectionCensoredName' in json:
-            self.collection_censored_name = json['collectionCensoredName']
-
-        if 'collectionViewUrl' in json:
-            self.collection_view_url = json['collectionViewUrl']
-
-        if 'collectionPrice' in json:
-            self.collection_price = json['collectionPrice']
-
-        if 'trackPrice' in json:
-            self.track_price = json['trackPrice']
-
-        if 'trackRentalPrice' in json:
-            self.track_rental_price = json['trackRentalPrice']
-
-        if 'collectionHdPrice' in json:
-            self.collection_hd_price = json['collectionHdPrice']
-
-        if 'trackHdPrice' in json:
-            self.track_hd_price = json['trackHdPrice']
-
-        if 'trackHdRentalPrice' in json:
-            self.track_hd_rental_price = json['trackHdRentalPrice']
-
-        if 'releaseDate' in json:
-            self.release_date = json['releaseDate']
-
-        if 'collectionExplicitness' in json:
-            self.collection_explicitness = json['collectionExplicitness']
-
-        if 'trackExplicitness' in json:
-            self.track_explicitness = json['trackExplicitness']
+            self.artist_radio_url: str = json['radioStationUrl']
 
         if 'trackTimeMillis' in json:
-            self.track_time = json['trackTimeMillis']
-
-        if 'discCount' in json:
-            self.disc_count = json['discCount']
-
-        if 'discNumber' in json:
-            self.disc_number = json['discNumber']
-
-        if 'country' in json:
-            self.country = json['country']
-
-        if 'currency' in json:
-            self.currency = json['currency']
-
-        if 'copyright' in json:
-            self.copyright = json['copyright']
-
-        if 'contentAdvisoryRating' in json:
-            self.content_advisory_rating = json['contentAdvisoryRating']
-
-        if 'shortDescription' in json:
-            self.short_description = json['shortDescription']
-
-        if 'longDescription' in json:
-            self.long_description = json['longDescription']
-
-        if 'isStreamable' in json:
-            self.is_streamable = json['isStreamable']
+            self.track_time: int = json['trackTimeMillis']
 
         if 'fileSizeBytes' in json:
             self.file_size = json['fileSizeBytes']
 
-        if 'genres' in json:
-            self.genres = json['genres']
-
-        if 'price' in json:
-            self.price = json['price']
-
-        if 'description' in json:
-            self.description = json['description']
-
-        if 'genreIds' in json:
-            self.genre_ids = json['genreIds']
-
-        if 'artistIds' in json:
-            self.artist_ids = json['artistIds']
-
-        if 'formattedPrice' in json:
-            self.formatted_price = json['formattedPrice']
-
-        if 'averageUserRating' in json:
-            self.average_user_rating = json['averageUserRating']
-
-        if 'userRatingCount' in json:
-            self.user_rating_count = json['userRatingCount']
-
-        if 'screenshotUrls' in json:
-            self.screenshot_urls = json['screenshotUrls']
-
-        if 'ipadScreenshotUrls' in json:
-            self.ipad_screenshot_urls = json['ipadScreenshotUrls']
-
-        if 'features' in json:
-            self.features = json['features']
-
-        if 'supportedDevices' in json:
-            self.supported_devices = json['supportedDevices']
-
-        if 'advisories' in json:
-            self.advisories = json['advisories']
-
-        if 'isGameCenterEnabled' in json:
-            self.is_game_center_enabled = json['isGameCenterEnabled']
-
-        if 'userRatingCountForCurrentVersion' in json:
-            self.user_rating_count_for_current_version = json['userRatingCountForCurrentVersion']
-
         if 'languageCodesISO2A' in json:
             self.language_codes = json['languageCodesISO2A']
 
-        if 'averageUserRatingForCurrentVersion' in json:
-            self.average_user_rating_for_current_version = json['averageUserRatingForCurrentVersion']
+    def __getattr__(self, item: str) -> Any:
+        components = item.split('_')
+        key = components[0] + ''.join(x.title() for x in components[1:])
+        try:
+            return self.json[key]
+        except KeyError:
+            raise AttributeError
 
-        if 'trackContentRating' in json:
-            self.track_content_rating = json['trackContentRating']
-
-        if 'version' in json:
-            self.version = json['version']
-
-        if 'sellerName' in json:
-            self.seller_name = json['sellerName']
-
-        if 'sellerUrl' in json:
-            self.seller_url = json['sellerUrl']
-
-        if 'bundleId' in json:
-            self.bundle_id = json['bundleId']
-
-        if 'releaseNotes' in json:
-            self.release_notes = json['releaseNotes']
-
-        if 'isVppDeviceBasedLicensingEnabled' in json:
-            self.is_vpp_device_based_licensing_enabled = json['isVppDeviceBasedLicensingEnabled']
-
-        if 'minimumOsVersion' in json:
-            self.minimum_os_version = json['minimumOsVersion']
-
-    def get_country(self, format='alpha_2'):
+    def get_country(self, format: str = 'alpha_2') -> str:
         """
         Returns the item's country in the specified format.
 
@@ -248,9 +144,9 @@ class ResultItem(object):
                        Valid formats include 'alpha_2', 'alpha_3' and 'name'.
         :return: String. The item's country in the specified format.
         """
-        return getattr(pycountry.countries.get(alpha_3=self.country), format)
+        return getattr(pycountry.countries.get(alpha_3=self.country), format)  # type: ignore
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Retrieves all keys in the class as a String
         :return: String. All the keys available in the class

--- a/itunespy/track.py
+++ b/itunespy/track.py
@@ -19,13 +19,6 @@ class Track(result_item.ResultItem):
     """
     Defines a Track whether it's a music track or a movie or a show episode
     """
-    def __init__(self, json: Dict[str, Any]) -> None:
-        """
-        Initializes the ResultItem class from the JSON provided
-        :param json: String. Raw JSON data to fetch information from
-        """
-        result_item.ResultItem.__init__(self, json)
-
     def get_track_time_minutes(self, round_number: int = 2) -> float:
         """
         Retrieves the track's length and converts it to minutes

--- a/itunespy/track.py
+++ b/itunespy/track.py
@@ -11,33 +11,33 @@
 # You should have received a
 #  copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
+from typing import Any, Dict
 
-import itunespy
 from itunespy import result_item
 
 class Track(result_item.ResultItem):
     """
     Defines a Track whether it's a music track or a movie or a show episode
     """
-    def __init__(self, json):
+    def __init__(self, json: Dict[str, Any]) -> None:
         """
         Initializes the ResultItem class from the JSON provided
         :param json: String. Raw JSON data to fetch information from
         """
         result_item.ResultItem.__init__(self, json)
 
-    def get_track_time_minutes(self, round_number=2):
+    def get_track_time_minutes(self, round_number: int = 2) -> float:
         """
         Retrieves the track's length and converts it to minutes
         :param round_number: Int. Number of decimals to round the minutes
-        :return: Int. Track length in minutes
+        :return: Float. Track length in minutes
         """
         return round(self.track_time / 60000, round_number)
 
-    def get_track_time_hours(self, round_number=2):
+    def get_track_time_hours(self, round_number: int = 2) -> float:
         """
         Retrieves the track's length and converts it to hours
         :param round_number: Int. Number of decimals to round the hours
-        :return: Int. Track length in hours
+        :return: Float. Track length in hours
         """
         return round(self.track_time / 6000000, round_number)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,16 @@
+[mypy]
+follow_imports = silent
+strict_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+check_untyped_defs = True
+no_implicit_reexport = True
+warn_unused_configs = True
+disallow_incomplete_defs = True
+disallow_untyped_decorators = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+warn_return_any = True
+
+[mypy-pycountry]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author_email='fgonzaleva@gmail.com',
     url='http://github.com/spaceisstrange/itunespy',
     packages=['itunespy'],
-    install_requires=['requests>=2.8'],
+    install_requires=['requests>=2.8', 'pycountry>=19.8'],
     license='MIT',
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ setup(
     url='http://github.com/spaceisstrange/itunespy',
     packages=['itunespy'],
     install_requires=['requests>=2.8', 'pycountry>=19.8'],
+    extras_require={
+        'dev': ['mypy']
+    },
     license='MIT',
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -19,8 +22,9 @@ setup(
         'License :: OSI Approved :: MIT License',
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )


### PR DESCRIPTION
This pull request includes a number of things:
- Type annotations for every function
- URL escaping via `urllib.parse`. This has the following implications:
  - Simpler Code
  - Fixes a bug where if only the `artist_amg_id` or only the `ups` was specified for a lookup operation the function would raise an error.
  - Fixes a bug where special characters in search term or other query parameters would not be properly escaped.
- Dynamic property access in `ResultItem` this makes it easier to support any new attributes added to the iTunes Search API. Known attributes are included as type hints to help type checkers and IDEs.
- A new `Artist` class that is made the superclass of all artist types. The main purpose of this is to provide a more intuitive way to type hint any artist (which is needed `search_director` for example).
- The `__repr__` function now returns the underlying JSON object of a `ResultItem`.
- A Github Actions Workflow that checks the consistency of type annotations via MyPy.
- Drop support for Python 3.4

I did try to make all of the changes backwards compatible. The following functions may behave slightly differently:
- Performing lookups and searches does not raise an error anymore if the `artist_amg_id` or `ups` is not a `str` (at least in some cases). I consider this a bugfix.
- `collection_type`, `artist_type` and `track_type` are now available in a `ResultItem` even if it does not have a `wrapperType`. This is to provide a more consistent interface allowing to query arbitrary fields in a result.
- The `__repr__` function of `ResultItems` now returns a different value.